### PR TITLE
Externalizing Environment Settings

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,0 +1,6 @@
+BUILD_PATH=C:\\SourceCode\\Fritz\\StreamDeckToolkit\\src\\SamplePlugin\\bin\\Debug\\netcoreapp2.2\\win10-x64
+WINEXE_NAME=SamplePlugin.exe
+OSXEXE_NAME=SamplePlugin
+
+DEVICE_ID=55F16B35884A859CCE4FFA1FC8D3DE5B
+DEVICE_PORT=3000

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # StreamDeckEmulator
 
-A simple emulator for the Stream Deck Application to allow plugin developers to develop, test, and debug their plugins without requiring a physical [Stream Deck][https://www.elgato.com/en/gaming/stream-deckgit] device.
+A simple emulator for the Stream Deck Application to allow plugin developers to develop, test, and debug their plugins without requiring a physical [Stream Deck](https://www.elgato.com/en/gaming/stream-deckgit) device.
 
 
 ### Pre-requisites
 
-In order to be able to run this emulator, you will need to have [Node.js][https://nodejs.org/] installed. The most recent <abbr title="Long Term Service">LTS</abbr> is suggested.
+In order to be able to run this emulator, you will need to have [Node.js](https://nodejs.org/) installed. The most recent <abbr title="Long Term Service">LTS</abbr> is suggested.
 
 ### Getting Started
 
@@ -14,8 +14,8 @@ In order to be able to run this emulator, you will need to have [Node.js][https:
 3. Run `npm install`.
 4. Create a copy of the .env_sample file: `cp .env_sample .env`.
 5. Update `.env` file to set your environment specific values.
-   1. Update the value of `BUILD_PATH` to be the build output path of your plugin's executable
-   2. Update the value of `config.executable.exe` to be the filename of the your plugin's executable
+   1. Update the value of `BUILD_PATH` to be the build output path of your plugin's executable.
+   2. Update the value of `WINEXE_NAME` or `OSXEXE_NAME` to be the filename of the your plugin's executable.
 6. Run `npm start` to launch the emulator.
 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # StreamDeckEmulator
 
-A simple emulator for the Stream Deck Application to allow plugin developers to develop, test, and debug their plugins without requiring a physical [Stream Deck](https://www.elgato.com/en/gaming/stream-deckgit) device.
+A simple emulator for the Stream Deck Application to allow plugin developers to develop, test, and debug their plugins without requiring a physical [Stream Deck][] device.
 
 
 ### Pre-requisites
 
-In order to be able to run this emulator, you will need to have [Node.js](https://nodejs.org/) installed. The most recent <abbr title="Long Term Service">LTS</abbr> is suggested.
+In order to be able to run this emulator, you will need to have [Node.js][] installed. The most recent <abbr title="Long Term Service">LTS</abbr> is suggested.
 
 ### Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StreamDeckEmulator
 
-A simple emulator for the Stream Deck Application to allow plugin developers to develop, test, and debug their plugins without requiring a physical [Stream Deck][https://www.elgato.com/en/gaming/stream-deck] device.
+A simple emulator for the Stream Deck Application to allow plugin developers to develop, test, and debug their plugins without requiring a physical [Stream Deck][https://www.elgato.com/en/gaming/stream-deckgit] device.
 
 
 ### Pre-requisites

--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 # StreamDeckEmulator
-A simple emulator for the Stream Deck Application to allow plugin developers to develop, test, and debug their plugins without requiring a physical [Stream Deck][] device.
 
-
-## Getting Started
+A simple emulator for the Stream Deck Application to allow plugin developers to develop, test, and debug their plugins without requiring a physical [Stream Deck][https://www.elgato.com/en/gaming/stream-deck] device.
 
 
 ### Pre-requisites
 
-In order to be able to run this emulator, you will need to have [Node.js][] installed. The most recent <abbr title="Long Term Service">LTS</abbr> is suggested.
+In order to be able to run this emulator, you will need to have [Node.js][https://nodejs.org/] installed. The most recent <abbr title="Long Term Service">LTS</abbr> is suggested.
 
+### Getting Started
 
-### Edit the Configuration
-
-1. Open the file `config.js` in your prefered editor
-2. Update the value of `config.executable.path` to be the build output path of your plugin's executable
-3. Update the value of `config.executable.exe` to be the filename of the your plugin's executable
+1. Clone the repository using git: `git clone https://github.com/FritzAndFriends/StreamDeckEmulator.git`.
+2. Change directory to the repository: `cd StreamDeckEmulator`.
+3. Run `npm install`.
+4. Create a copy of the .env_sample file: `cp .env_sample .env`.
+5. Update `.env` file to set your environment specific values.
+   1. Update the value of `BUILD_PATH` to be the build output path of your plugin's executable
+   2. Update the value of `config.executable.exe` to be the filename of the your plugin's executable
+6. Run `npm start` to launch the emulator.
 
 
 ### Starting and Stopping the Emulator
 
 1. Open a command prompt/terminal/shell and navigate to the current directory.
-2. Start the emulator with the command `node index.js`
+2. Start the emulator with the command `npm start`
 3. When you are done, press <kbd>Ctrl</kbd>+<kbd>C</kbd> to stop the emulator.
 
 
@@ -31,8 +33,6 @@ In order to be able to run this emulator, you will need to have [Node.js][] inst
 At this time, the emulator only supports emulating a button press, which results in a `keyUp` event with its respective payload.
 
 To simulate the `keyUp` event, press the <kbd>B</kbd> button on your keyboard.
-
-
 
 
 

--- a/config.js
+++ b/config.js
@@ -1,13 +1,15 @@
+require("dotenv").config();
+
 let config = {};
 config.executable = {
-    path: "C:\\SourceCode\\Fritz\\StreamDeckToolkit\\src\\SamplePlugin\\bin\\Debug\\netcoreapp2.2\\win10-x64",
+    path: process.env.BUILD_PATH,
     manifest: "manifest.json",
-    winexe: "SamplePlugin.exe",
-    osxexe: "SamplePlugin"
+    winexe: process.env.WINEXE_NAME,
+    osxexe: process.env.OSXEXE_NAME
 };
 config.server = {
-    deviceId : "55F16B35884A859CCE4FFA1FC8D3DE5B",
-    port : 3000,
+    deviceId : process.env.DEVICE_ID,
+    port : process.env.DEVICE_PORT,
     winplatform: "windows",
     osxplatform : "osx"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,16 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+    },
+    "dotenv": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+    },
     "readline-sync": {
       "version": "1.4.9",
       "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.9.tgz",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "Basic Stream Deck hardware emulator",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
   "license": "MIT",
   "dependencies": {
     "colors": "^1.3.3",
+    "dotenv": "^6.2.0",
     "readline-sync": "^1.4.9",
     "ws": "^6.1.2"
   }


### PR DESCRIPTION
The current implementation uses a config file with hard-coded values. This PR adds a dependency on `dotenv` to allow the use of environment variables to pass these configuration options at runtime. For ease of use, it also will pull in any values found in a `.env` file.

I also updated the README to include getting started section.