### PR TITLE
[WIP] CLI Proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,28 @@
 A simple emulator for the Stream Deck Application to allow plugin developers to develop, test, and debug their plugins without requiring a physical [Stream Deck][] device.
 
 
-### Pre-requisites
+## Pre-requisites
 
 In order to be able to run this emulator, you will need to have [Node.js][] installed. The most recent <abbr title="Long Term Service">LTS</abbr> is suggested.
+
+## Setup
+
+```bash
+npm i -g streamdeckemulator
+```
+
+## Usage
+
+### Run the Emulator on a Specific Plugin
+
+```bash
+sde -p /path/to/built/streamdeck/plugin -e nameofplugin
+```
+
+### Using the Emulator
+
+
+## Local Development
 
 ### Getting Started
 
@@ -16,7 +35,6 @@ In order to be able to run this emulator, you will need to have [Node.js][] inst
 5. Update `.env` file to set your environment specific values.
    1. Update the value of `BUILD_PATH` to be the build output path of your plugin's executable.
    2. Update the value of `WINEXE_NAME` or `OSXEXE_NAME` to be the filename of the your plugin's executable.
-6. Run `npm start` to launch the emulator.
 
 
 ### Starting and Stopping the Emulator
@@ -24,18 +42,6 @@ In order to be able to run this emulator, you will need to have [Node.js][] inst
 1. Open a command prompt/terminal/shell and navigate to the current directory.
 2. Start the emulator with the command `npm start`
 3. When you are done, press <kbd>Ctrl</kbd>+<kbd>C</kbd> to stop the emulator.
-
-
-### Using the Emulator
-
-#### Simulating events
-
-At this time, the emulator only supports emulating a button press, which results in a `keyUp` event with its respective payload.
-
-To simulate the `keyUp` event, press the <kbd>B</kbd> button on your keyboard.
-
-
-
 
 <!-- Reference Links -->
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ sde -p /path/to/built/streamdeck/plugin -e nameofplugin
 
 ## Local Development
 
-### Getting Started
+### Runing local to the cloned repository
+
+#### Getting Started
 
 1. Clone the repository using git: `git clone https://github.com/FritzAndFriends/StreamDeckEmulator.git`.
 2. Change directory to the repository: `cd StreamDeckEmulator`.
@@ -37,11 +39,20 @@ sde -p /path/to/built/streamdeck/plugin -e nameofplugin
    2. Update the value of `WINEXE_NAME` or `OSXEXE_NAME` to be the filename of the your plugin's executable.
 
 
-### Starting and Stopping the Emulator
+#### Starting and Stopping the Emulator
 
 1. Open a command prompt/terminal/shell and navigate to the current directory.
 2. Start the emulator with the command `npm start`
 3. When you are done, press <kbd>Ctrl</kbd>+<kbd>C</kbd> to stop the emulator.
+
+### Running as a global tool
+
+1. Clone the repository using git: `git clone https://github.com/FritzAndFriends/StreamDeckEmulator.git`.
+2. Change directory to the repository: `cd StreamDeckEmulator`.
+3. Run `npm install`.
+4. Run `npm link`
+
+You should now have the CLI command `sde` installed globally as if it were installed via NPM.
 
 <!-- Reference Links -->
 

--- a/bin/run/index.js
+++ b/bin/run/index.js
@@ -1,0 +1,27 @@
+var Chalk = require('chalk');
+var Cli = require('structured-cli');
+
+module.exports = Cli.createCommand('run', {
+  description: 'Starts the emulator',
+  options: {
+    'path': {
+      alias: 'p',
+      required: true,
+      description: 'The path to your Stream Deck Plugin directory.',
+      dest: 'path',
+      type: 'string'
+    },
+    'executable': {
+      alias: 'e',
+      required: true,
+      description: 'The executable file name for your Stream Deck Plugin.',
+      dest: 'executable',
+      type: 'string'
+    }
+  },
+  handler: handleRun
+});
+
+function handleRun(args) {
+  console.log(Chalk.bold(`Running ${args.executable} located in ${args.path}`));
+}

--- a/bin/run/index.js
+++ b/bin/run/index.js
@@ -8,7 +8,7 @@ function handleRun(args) {
 
   spawnSync('npm', ['start'], {
     stdio: 'inherit',
-    cwd: path.resolve(__dirname, '../../');,
+    cwd: path.resolve(__dirname, '../../'),
     env: Object.assign(process.env, {
       'BUILD_PATH': args.path,
       'WINEXE_NAME': args.executable,

--- a/bin/run/index.js
+++ b/bin/run/index.js
@@ -1,5 +1,5 @@
-var Chalk = require('chalk');
-var Cli = require('structured-cli');
+const Chalk = require('chalk');
+const Cli = require('structured-cli');
 
 module.exports = Cli.createCommand('run', {
   description: 'Starts the emulator',

--- a/bin/run/index.js
+++ b/bin/run/index.js
@@ -6,7 +6,12 @@ function handleRun(args) {
   console.log(Chalk.bold(`Running Emulator on ${args.executable} located in ${args.path}`));
 
   spawnSync('npm', ['start'], {
-    stdio: 'inherit'
+    stdio: 'inherit',
+    env: Object.assign(process.env, {
+      'BUILD_PATH': args.path,
+      'WINEXE_NAME': args.executable,
+      'OSXEXE_NAME': args.executable
+    }),
   });
 }
 

--- a/bin/run/index.js
+++ b/bin/run/index.js
@@ -1,5 +1,15 @@
 const Chalk = require('chalk');
 const Cli = require('structured-cli');
+const { spawnSync } = require('child_process')
+
+function handleRun(args) {
+  console.log(Chalk.bold(`Running Emulator on ${args.executable} located in ${args.path}`));
+  
+  const emu = spawnSync('npm', ['start'], {
+    stdio: 'inherit'
+  });
+
+}
 
 module.exports = Cli.createCommand('run', {
   description: 'Starts the emulator',
@@ -21,7 +31,3 @@ module.exports = Cli.createCommand('run', {
   },
   handler: handleRun
 });
-
-function handleRun(args) {
-  console.log(Chalk.bold(`Running ${args.executable} located in ${args.path}`));
-}

--- a/bin/run/index.js
+++ b/bin/run/index.js
@@ -5,11 +5,10 @@ const { spawnSync } = require('child_process')
 
 function handleRun(args) {
   console.log(Chalk.bold(`Running Emulator on ${args.executable} located in ${args.path}`));
-  const cwd = path.resolve(__dirname, '../../');
 
   spawnSync('npm', ['start'], {
     stdio: 'inherit',
-    cwd: cwd,
+    cwd: path.resolve(__dirname, '../../');,
     env: Object.assign(process.env, {
       'BUILD_PATH': args.path,
       'WINEXE_NAME': args.executable,

--- a/bin/run/index.js
+++ b/bin/run/index.js
@@ -1,12 +1,15 @@
+const path = require("path");
 const Chalk = require('chalk');
 const Cli = require('structured-cli');
 const { spawnSync } = require('child_process')
 
 function handleRun(args) {
   console.log(Chalk.bold(`Running Emulator on ${args.executable} located in ${args.path}`));
+  const cwd = path.resolve(__dirname, '../../');
 
   spawnSync('npm', ['start'], {
     stdio: 'inherit',
+    cwd: cwd,
     env: Object.assign(process.env, {
       'BUILD_PATH': args.path,
       'WINEXE_NAME': args.executable,

--- a/bin/run/index.js
+++ b/bin/run/index.js
@@ -4,11 +4,10 @@ const { spawnSync } = require('child_process')
 
 function handleRun(args) {
   console.log(Chalk.bold(`Running Emulator on ${args.executable} located in ${args.path}`));
-  
-  const emu = spawnSync('npm', ['start'], {
+
+  spawnSync('npm', ['start'], {
     stdio: 'inherit'
   });
-
 }
 
 module.exports = Cli.createCommand('run', {

--- a/bin/run/index.js
+++ b/bin/run/index.js
@@ -1,12 +1,11 @@
 const path = require("path");
 const Chalk = require('chalk');
 const Cli = require('structured-cli');
-const { spawnSync } = require('child_process')
+const { spawn } = require('cross-spawn');
 
 function handleRun(args) {
   console.log(Chalk.bold(`Running Emulator on ${args.executable} located in ${args.path}`));
-
-  spawnSync('npm', ['start'], {
+  spawn.sync('npm', ['start'], {
     stdio: 'inherit',
     cwd: path.resolve(__dirname, '../../'),
     env: Object.assign(process.env, {

--- a/bin/sde
+++ b/bin/sde
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 
-var _ = require('lodash');
-var Chalk = require('chalk');
-var Cli = require('structured-cli');
-var Updates = require('update-notifier');
-var Package = require('../package.json');
+const _ = require('lodash');
+const Chalk = require('chalk');
+const Cli = require('structured-cli');
+const Updates = require('update-notifier');
+const Package = require('../package.json');
 
 // Check latest version on npm
 // and notify user if newer version
 // is available.
 Updates({ pkg: Package }).notify();
 
-var cli = Cli.createApp({
+const cli = Cli.createApp({
     description: Package.description,
     version: Package.version,
     epilog: Chalk.underline('Sample usage:') + '\n'

--- a/bin/sde
+++ b/bin/sde
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+var _ = require('lodash');
+var Chalk = require('chalk');
+var Cli = require('structured-cli');
+var Updates = require('update-notifier');
+var Package = require('../package.json');
+
+// Check latest version on npm
+// and notify user if newer version
+// is available.
+Updates({ pkg: Package }).notify();
+
+var cli = Cli.createApp({
+    description: Package.description,
+    version: Package.version,
+    epilog: Chalk.underline('Sample usage:') + '\n'
+});
+
+cli.addChild(require('./run'));
+
+Cli.run(cli)
+    // Code: 1
+    .catch(_.matchesProperty('code', 'E_CANCELLED'), function (err) {
+        console.error(err.message);
+
+        process.exit(1);
+    })
+    // Code: 2
+    .catch(_.matchesProperty('code', 'E_INVALID'), function (err) {
+        console.error(err.parser.formatUsage());
+        console.error(Chalk.red(err.message));
+
+        process.exit(2);
+    })
+    // Code: 3
+    .catch(_.matchesProperty('code', 'E_HINT'), function (err) {
+        console.error(err.message);
+
+        process.exit(3);
+    })
+    // Code: 4
+    .catch(_.matchesProperty('code', 'E_TIMEOUT'), function (err) {
+        console.error(Chalk.red(err.message));
+
+        process.exit(4);
+    })
+    // Code: 5
+    .catch(_.matchesProperty('code', 'E_NOTFOUND'), function (err) {
+        console.error(Chalk.red(err.message));
+
+        process.exit(5);
+    })
+    // Code: 6
+    .catch(_.matchesProperty('code', 'E_BADREQUEST'), function (err) {
+        console.error(Chalk.red(err.message));
+
+        process.exit(6);
+    })
+    // Code: 7
+    .catch(_.matchesProperty('code', 'E_SERVERERROR'), function (err) {
+        console.error(Chalk.red(err.message));
+
+        process.exit(7);
+    })
+    // Code: 8
+    .catch(_.matchesProperty('code', 'E_NOTAUTHORIZED'), function (err) {
+        console.error(Chalk.red(err.message));
+
+        process.exit(8);
+    })
+    // Code: 99
+    .catch(function (err) {
+        console.error(Chalk.red('Uncaught error: ', err.message));
+        console.error(err.stack);
+        console.error('Please report this at: https://github.com/FritzAndFriends/StreamDeckEmulator/issues');
+
+        process.exit(99);
+    })
+    .then(function () {
+        process.exit(0);
+    });

--- a/bin/sde
+++ b/bin/sde
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 
-const _ = require('lodash');
-const Chalk = require('chalk');
-const Cli = require('structured-cli');
-const Updates = require('update-notifier');
-const Package = require('../package.json');
+const path = require("path");
+const _ = require("lodash");
+const Chalk = require("chalk");
+const Cli = require("structured-cli");
+const Updates = require("update-notifier");
+const packagePath = path.resolve(__dirname, "../package.json");
+const Package = require(packagePath);
 
 // Check latest version on npm
 // and notify user if newer version
@@ -12,71 +14,73 @@ const Package = require('../package.json');
 Updates({ pkg: Package }).notify();
 
 const cli = Cli.createApp({
-    description: Package.description,
-    version: Package.version,
-    epilog: Chalk.underline('Sample usage:') + '\n'
+  description: Package.description,
+  version: Package.version,
+  epilog: Chalk.underline("Sample usage:") + "\n"
 });
 
-cli.addChild(require('./run'));
+cli.addChild(require("./run"));
 
 Cli.run(cli)
-    // Code: 1
-    .catch(_.matchesProperty('code', 'E_CANCELLED'), function (err) {
-        console.error(err.message);
+  // Code: 1
+  .catch(_.matchesProperty("code", "E_CANCELLED"), function(err) {
+    console.error(err.message);
 
-        process.exit(1);
-    })
-    // Code: 2
-    .catch(_.matchesProperty('code', 'E_INVALID'), function (err) {
-        console.error(err.parser.formatUsage());
-        console.error(Chalk.red(err.message));
+    process.exit(1);
+  })
+  // Code: 2
+  .catch(_.matchesProperty("code", "E_INVALID"), function(err) {
+    console.error(err.parser.formatUsage());
+    console.error(Chalk.red(err.message));
 
-        process.exit(2);
-    })
-    // Code: 3
-    .catch(_.matchesProperty('code', 'E_HINT'), function (err) {
-        console.error(err.message);
+    process.exit(2);
+  })
+  // Code: 3
+  .catch(_.matchesProperty("code", "E_HINT"), function(err) {
+    console.error(err.message);
 
-        process.exit(3);
-    })
-    // Code: 4
-    .catch(_.matchesProperty('code', 'E_TIMEOUT'), function (err) {
-        console.error(Chalk.red(err.message));
+    process.exit(3);
+  })
+  // Code: 4
+  .catch(_.matchesProperty("code", "E_TIMEOUT"), function(err) {
+    console.error(Chalk.red(err.message));
 
-        process.exit(4);
-    })
-    // Code: 5
-    .catch(_.matchesProperty('code', 'E_NOTFOUND'), function (err) {
-        console.error(Chalk.red(err.message));
+    process.exit(4);
+  })
+  // Code: 5
+  .catch(_.matchesProperty("code", "E_NOTFOUND"), function(err) {
+    console.error(Chalk.red(err.message));
 
-        process.exit(5);
-    })
-    // Code: 6
-    .catch(_.matchesProperty('code', 'E_BADREQUEST'), function (err) {
-        console.error(Chalk.red(err.message));
+    process.exit(5);
+  })
+  // Code: 6
+  .catch(_.matchesProperty("code", "E_BADREQUEST"), function(err) {
+    console.error(Chalk.red(err.message));
 
-        process.exit(6);
-    })
-    // Code: 7
-    .catch(_.matchesProperty('code', 'E_SERVERERROR'), function (err) {
-        console.error(Chalk.red(err.message));
+    process.exit(6);
+  })
+  // Code: 7
+  .catch(_.matchesProperty("code", "E_SERVERERROR"), function(err) {
+    console.error(Chalk.red(err.message));
 
-        process.exit(7);
-    })
-    // Code: 8
-    .catch(_.matchesProperty('code', 'E_NOTAUTHORIZED'), function (err) {
-        console.error(Chalk.red(err.message));
+    process.exit(7);
+  })
+  // Code: 8
+  .catch(_.matchesProperty("code", "E_NOTAUTHORIZED"), function(err) {
+    console.error(Chalk.red(err.message));
 
-        process.exit(8);
-    })
-    // Code: 99
-    .catch(function (err) {
-        console.error(Chalk.red('Uncaught error: ', err.message));
-        console.error(err.stack);
-        console.error('Please report this at: https://github.com/FritzAndFriends/StreamDeckEmulator/issues');
+    process.exit(8);
+  })
+  // Code: 99
+  .catch(function(err) {
+    console.error(Chalk.red("Uncaught error: ", err.message));
+    console.error(err.stack);
+    console.error(
+      "Please report this at: https://github.com/FritzAndFriends/StreamDeckEmulator/issues"
+    );
 
-        process.exit(99);
-    })
-    .then(function () {
-        process.exit(0);
-    });
+    process.exit(99);
+  })
+  .then(function() {
+    process.exit(0);
+  });

--- a/config.js
+++ b/config.js
@@ -1,6 +1,5 @@
 const dotenv = require("dotenv");
 const envConfig = dotenv.config();
-require('colors');
 
 if (envConfig.error){
     const errorMessage = '>>>  The environment ("./.env") file could not be loaded. Check that it exists and that it is valid. <<<';

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const Chalk = require('chalk');
 const config = require('./config');
 const { fork } = require('child_process');
 const rlSync = require('readline-sync');
-const exec = require('child_process').execFile;
+const { spawn } = require('cross-spawn');
 const path = require('path');
 const os = require('os');
 let manifest = require(path.join(config.executable.path, config.executable.manifest));
@@ -33,7 +33,7 @@ let info = {
   };
 
 let registrationParams = ['-port', config.server.port, '-pluginUUID', manifest.Actions[0].UUID,'-registerEvent','registerEvent','-info', JSON.stringify(info)];
-exec(pluginExe, registrationParams, { cwd: config.executable.path }, (err, data) => {
+spawn(pluginExe, registrationParams, { cwd: config.executable.path }, (err, data) => {
     if(err){
         console.log(Chalk.red(`ERROR: ${err}`));
     } else {
@@ -41,7 +41,6 @@ exec(pluginExe, registrationParams, { cwd: config.executable.path }, (err, data)
     }
 } );
 
-// Type b at any time to send a KeyUp event to the plugin
 promptUser();
 
 function promptUser() {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Chalk = require('chalk');
+const Chalk = require('chalk');
 const config = require('./config');
 const { fork } = require('child_process');
 const rlSync = require('readline-sync');

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
+var Chalk = require('chalk');
 const config = require('./config');
 const { fork } = require('child_process');
-const colors = require('colors');
 const rlSync = require('readline-sync');
 const exec = require('child_process').execFile;
 const path = require('path');
@@ -9,7 +9,7 @@ let manifest = require(path.join(config.executable.path, config.executable.manif
 const pluginExe = os.platform == 'win32' ? config.executable.winexe : config.executable.osxexe;
 
 const forked = fork('server.js');
-console.log('<status>Web Socket Server Started....'.green);
+console.log(Chalk.green('<status>Web Socket Server Started....'));
 
 console.log('Green Text denotes hardware action\nGreen Highlight denotes hardware messages sent\nCyan highlight denotes messages received from plugin\n');
 
@@ -35,9 +35,9 @@ let info = {
 let registrationParams = ['-port', config.server.port, '-pluginUUID', manifest.Actions[0].UUID,'-registerEvent','registerEvent','-info', JSON.stringify(info)];
 exec(pluginExe, registrationParams, { cwd: config.executable.path }, (err, data) => {
     if(err){
-        console.log(`ERROR: ${err}`.red);
+        console.log(Chalk.red(`ERROR: ${err}`));
     } else {
-        console.log(`DATA: ${data}`.green);
+        console.log(Chalk.green(`DATA: ${data}`));
     }
 } );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,11 +122,13 @@
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "requires": {
-        "lru-cache": "^4.0.1",
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
@@ -176,6 +178,18 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
       }
     },
     "get-stream": {
@@ -333,6 +347,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "npm-run-path": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,25 +4,580 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "ansi-align": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "requires": {
+        "string-width": "^2.0.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
-    "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+    "bluebird": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+    },
+    "boxen": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "requires": {
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
+      }
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+    },
+    "capture-stack-trace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "ci-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "configstore": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "requires": {
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      }
+    },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "requires": {
+        "capture-stack-trace": "^1.0.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
     },
     "dotenv": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
       "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
     },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "requires": {
+        "ini": "^1.3.4"
+      }
+    },
+    "got": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "requires": {
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "is-ci": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+      "requires": {
+        "ci-info": "^1.5.0"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "requires": {
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "latest-version": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "requires": {
+        "package-json": "^4.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "requires": {
+        "pify": "^3.0.0"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "package-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "requires": {
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
+      }
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
+    },
     "readline-sync": {
       "version": "1.4.9",
       "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.9.tgz",
       "integrity": "sha1-PtqOZfI80qF+YTAbHwADOWr17No="
+    },
+    "registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "requires": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "requires": {
+        "rc": "^1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+    },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "requires": {
+        "semver": "^5.0.3"
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "structured-cli": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/structured-cli/-/structured-cli-1.0.5.tgz",
+      "integrity": "sha1-x9osNQ67FiWo1F1l6b4dCEjHxPY=",
+      "requires": {
+        "argparse": "^1.0.6",
+        "bluebird": "^3.3.1",
+        "lodash": "^4.3.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "requires": {
+        "execa": "^0.7.0"
+      }
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+    },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "requires": {
+        "crypto-random-string": "^1.0.0"
+      }
+    },
+    "unzip-response": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+    },
+    "update-notifier": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+      "requires": {
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      }
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "requires": {
+        "prepend-http": "^1.0.1"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "widest-line": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+      "requires": {
+        "string-width": "^2.1.1"
+      }
+    },
+    "write-file-atomic": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
     },
     "ws": {
       "version": "6.1.3",
@@ -31,6 +586,16 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,7 @@
   "author": "",
   "license": "MIT",
   "homepage": "https://github.com/FritzAndFriends/StreamDeckEmulator",
-  "repository": {
-    "type": "git",
-    "url": "git@github.com/FritzAndFriends/StreamDeckEmulator.git"
-  },
+  "repository": "github:FritzAndFriends/StreamDeckEmulator",
   "bugs": {
     "url": "https://github.com/FritzAndFriends/StreamDeckEmulator/issues"
   },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,14 @@
   },
   "author": "",
   "license": "MIT",
+  "homepage": "https://github.com/FritzAndFriends/StreamDeckEmulator",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com/FritzAndFriends/StreamDeckEmulator.git"
+  },
+  "bugs": {
+    "url": "https://github.com/FritzAndFriends/StreamDeckEmulator/issues"
+  },
   "dependencies": {
     "chalk": "^2.4.2",
     "dotenv": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "Basic Stream Deck hardware emulator",
   "main": "index.js",
+  "bin": {
+    "sde": "./bin/sde"
+  },
   "scripts": {
     "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,12 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "colors": "^1.3.3",
+    "chalk": "^2.4.2",
     "dotenv": "^6.2.0",
+    "lodash": "^4.17.11",
     "readline-sync": "^1.4.9",
+    "structured-cli": "^1.0.5",
+    "update-notifier": "^2.5.0",
     "ws": "^6.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
+    "cross-spawn": "^6.0.5",
     "dotenv": "^6.2.0",
     "lodash": "^4.17.11",
     "readline-sync": "^1.4.9",

--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
-var Chalk = require('chalk');
+const Chalk = require('chalk');
 const config = require('./config');
 const path = require('path');
 let manifest = require(path.join(config.executable.path, config.executable.manifest));

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
+var Chalk = require('chalk');
 const config = require('./config');
-const colors = require('colors');
 const path = require('path');
 let manifest = require(path.join(config.executable.path, config.executable.manifest));
 
@@ -15,19 +15,19 @@ server.on('connection', (socket) => {
         console.log(msg.bgCyan.black);
         switch(evt.event) {
             case 'showOk':
-                console.log('*******OK ICON IS SHOWN\n'.green);
+                console.log(Chalk.green('*******OK ICON IS SHOWN\n'));
                 break;
             case 'showAlert':
-                console.log('*******ALERT ICON IS DISPLAYED\n'.green);
+                console.log(Chalk.green('*******ALERT ICON IS DISPLAYED\n'));
                 break;
             case 'registerEvent':
-                console.log(`********PLUGIN REGISTERED: uuid=${evt.uuid}\n`.green);
+                console.log(Chalk.green(`********PLUGIN REGISTERED: uuid=${evt.uuid}\n`));
                 break;
             case 'openUrl':
-                console.log(`********OPENING URL ${evt.payload.url}\n`.green)
+                console.log(Chalk.green(`********OPENING URL ${evt.payload.url}\n`));
                 break;
             case 'setTitle':
-                console.log(`********TITLE SET: title: ${evt.payload.title} - Sending titleParametersDidChange event to plugin\n`.green)
+                console.log(Chalk.green(`********TITLE SET: title: ${evt.payload.title} - Sending titleParametersDidChange event to plugin\n`.green));
                 var json = {
                     'action': manifest.Actions[0].UUID, 
                     'event': 'titleParametersDidChange', 
@@ -52,15 +52,15 @@ server.on('connection', (socket) => {
                       }
                     }
                 };
-                console.log(JSON.stringify(json).bgGreen.black);
+                console.log(Chalk.black.bgGreen(JSON.stringify(json)));
                 _socket.send(JSON.stringify(json));
                 break;
             case 'setSettings':
-                console.log(`********SETTINGS STORED: ${JSON.stringify(evt.payload)} *******\n`.green);
+                console.log(Chalk.green(`********SETTINGS STORED: ${JSON.stringify(evt.payload)} *******\n`));
                 _settings = evt.payload;
                 break;
             default: 
-                console.log(`********UNKNOWN MESSAGE ${msg}\n`.red);
+                console.log(Chalk.red(`********UNKNOWN MESSAGE ${msg}\n`));
                 break;
         }
     });
@@ -87,22 +87,22 @@ process.on('message', (msg) => {
     switch(msg) {
         case 'keyDown':
             json.event = 'keyDown';
-            console.log(JSON.stringify(json).bgGreen.black);
+            console.log(Chalk.black.bgGreen(JSON.stringify(json)));
             _socket.send(JSON.stringify(json));
             break;
         case 'keyUp':
             json.event = 'keyUp';
-            console.log(JSON.stringify(json).bgGreen.black);
+            console.log(Chalk.black.bgGreen(JSON.stringify(json)));
             _socket.send(JSON.stringify(json));
             break;
         case 'willAppear': 
             json.event = 'willAppear';
-            console.log(JSON.stringify(json).bgGreen.black);
+            console.log(Chalk.black.bgGreen(JSON.stringify(json)));
             _socket.send(JSON.stringify(json));
             break;
         case 'willDisappear':
             json.event = 'willDisappear';
-            console.log(JSON.stringify(json).bgGreen.black);
+            console.log(Chalk.black.bgGreen(JSON.stringify(json)));
             _socket.send(JSON.stringify(json));
             break;
         case 'deviceDidConnect':
@@ -117,7 +117,7 @@ process.on('message', (msg) => {
                     }
                 },
             };
-            console.log(JSON.stringify(ddcJson).bgGreen.black);
+            console.log(Chalk.black.bgGreen(JSON.stringify(ddcJson)));
             _socket.send(JSON.stringify(ddcJson));
             break;
         case 'deviceDidDisconnect':
@@ -125,11 +125,11 @@ process.on('message', (msg) => {
                 'event': 'deviceDidDisconnect',
                 'device': config.server.deviceId
             };
-            console.log(JSON.stringify(dddJson).bgGreen.black);
+            console.log(Chalk.black.bgGreen(JSON.stringify(dddJson)));
             _socket.send(JSON.stringify(dddJson));
             break;
         default:
-            console.log(`\nUnknown Index message: ${msg}`.red);
+            console.log(Chalk.red(`\nUnknown Index message: ${msg}`));
             break;
     }
 });

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ server.on('connection', (socket) => {
     _socket = socket;
     _socket.on('message',(msg)=> {
         var evt = JSON.parse(msg);
-        console.log(msg.bgCyan.black);
+        console.log(Chalk.black.bgCyan(msg));
         switch(evt.event) {
             case 'showOk':
                 console.log(Chalk.green('*******OK ICON IS SHOWN\n'));
@@ -27,7 +27,7 @@ server.on('connection', (socket) => {
                 console.log(Chalk.green(`********OPENING URL ${evt.payload.url}\n`));
                 break;
             case 'setTitle':
-                console.log(Chalk.green(`********TITLE SET: title: ${evt.payload.title} - Sending titleParametersDidChange event to plugin\n`.green));
+                console.log(Chalk.green(`********TITLE SET: title: ${evt.payload.title} - Sending titleParametersDidChange event to plugin\n`));
                 var json = {
                     'action': manifest.Actions[0].UUID, 
                     'event': 'titleParametersDidChange', 


### PR DESCRIPTION
Fixes #8 

This is a proposed change for discussion.

The end goal for this project is to produce an npm installable tool. This tool would not be installed into a specific project, nobody is going to require it and use it inside their applications. Instead, we want to be able to execute the tool against any plugin project. This seems like the tool should be a CLI based tool like npm that can be globally installed and used anywhere.

This PR introduces a CLI `sde` with a single command `run` which takes two parameters `--path` and `--executable`. The CLI will spawn synchronous child process with its environment variables set correctly and run the emulator. Pretty simple.

This works for me on OSX, but I would like someone to test it on Windows. To test without actually installing the project from NPM, run the command from the root of the cloned repository like this:

```bash
./bin/sde run --path path/to/SamplePlugin/bin/Debug/netcoreapp2.2/osx-x64 --executable SamplePlugin
```

You should see the emulator startup and display it's menu. You can enter any of the commands and see it execute. To quit use ctrl-c.

Feedback? Questions?