### PR TITLE
Add help message for missing .env file

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,12 @@
-require("dotenv").config();
+const dotenv = require("dotenv");
+const envConfig = dotenv.config();
+require('colors');
+
+if (envConfig.error){
+    const errorMessage = '>>>  The environment ("./.env") file could not be loaded. Check that it exists and that it is valid. <<<';
+    console.error(errorMessage.bgRed.white.underline);
+    throw (errorMessage + '\n\t' + envConfig.error + '\n');
+}
 
 let config = {};
 config.executable = {


### PR DESCRIPTION
As a user (i.e. developer who doesn't RTFM - "Read The Friendly Manual"), I expect to find out what I did wrong or is missing, when trying to start the project.

This PR adds a message to display if the `.env` file is missing before exiting.