### PR TITLE
Add a "quit" option to the emulator

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,9 @@ function promptUser() {
     'wa' for willAppear
     'wd' for willDisappear
     'dc' for deviceDidConnect
-    'dd' for deviceDidDisconnect\n`);
+    'dd' for deviceDidDisconnect
+
+    To quit, press 'q'\n`);
 
     switch(cmd) {
         case 'kd':
@@ -72,11 +74,14 @@ function promptUser() {
             break;
         case 'dd':
             forked.send('deviceDidDisconnect');
+        case 'q':
+// Is this too much? Unnecessary? Over-achiever?
+            forked.disconnect();
+            forked.removeAllListeners();
+            forked.kill();
+            return;
         default:
             break;
     }
     promptUser();
 }
-
-
-


### PR DESCRIPTION
Have a more friendly/intuitive way of shutting down the emulator.

**NOTE**: Someone more versed in *Node.js*/JavaScript WebSockets (@codingbandit? @NotMyself?) really needs to review my "teardown" code. I may have gone a little overboard, made excessive and/or incorrect calls based on what seemed to make sense and autocomplete.